### PR TITLE
 when clicking on skip credits, skip to the next episode #4 

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/segments/SegmentSkipFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/segments/SegmentSkipFragment.kt
@@ -46,11 +46,13 @@ class SegmentSkipFragment() : Fragment() {
 
 	private fun buttonClicked() {
 		lastSegment?.let { segment ->
-			if (segment.type == SegmentType.CREDITS && playbackControllerContainer.playbackController?.hasNextItem() == true) {
-				playbackControllerContainer.playbackController?.next()
-			} else {
-				playbackControllerContainer.playbackController?.seek((segment.endTime.millis).toLong())
-			}
+			playbackControllerContainer.playbackController?.let { player ->
+				if (((segment.endTime.millis+180000) >= player.getDuration()) && player.hasNextItem() == true) {
+						player.next()
+					} else {
+						player.seek(segment.endTime.millis)
+					}
+				}
 		}
 	}
 

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/segments/SegmentSkipFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/segments/SegmentSkipFragment.kt
@@ -47,7 +47,7 @@ class SegmentSkipFragment() : Fragment() {
 	private fun buttonClicked() {
 		lastSegment?.let { segment ->
 			playbackControllerContainer.playbackController?.let { player ->
-				if (((segment.endTime.millis+180000) >= player.getDuration()) && player.hasNextItem() == true) {
+				if (((segment.endTime.millis+5000) >= player.getDuration()) && player.hasNextItem() == true) {
 						player.next()
 					} else {
 						player.seek(segment.endTime.millis)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/segments/SegmentSkipFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/segments/SegmentSkipFragment.kt
@@ -47,7 +47,7 @@ class SegmentSkipFragment() : Fragment() {
 	private fun buttonClicked() {
 		lastSegment?.let { segment ->
 			playbackControllerContainer.playbackController?.let { player ->
-				if (((segment.endTime.millis+5000) >= player.getDuration()) && player.hasNextItem() == true) {
+				if (((segment.endTime.millis+3000) > player.getDuration()) && player.hasNextItem() == true) {
 						player.next()
 					} else {
 						player.seek(segment.endTime.millis)

--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/segments/SegmentSkipFragment.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/segments/SegmentSkipFragment.kt
@@ -46,7 +46,11 @@ class SegmentSkipFragment() : Fragment() {
 
 	private fun buttonClicked() {
 		lastSegment?.let { segment ->
-			playbackControllerContainer.playbackController?.seek((segment.endTime.millis).toLong())
+			if (segment.type == SegmentType.CREDITS && playbackControllerContainer.playbackController?.hasNextItem() == true) {
+				playbackControllerContainer.playbackController?.next()
+			} else {
+				playbackControllerContainer.playbackController?.seek((segment.endTime.millis).toLong())
+			}
 		}
 	}
 


### PR DESCRIPTION
until now when i clicked on skip credit it skip to the end of the video and then i needed to click on next up, this fix that, so when i click on skip credits button it will just skip to the next episode.
this meant to mimic the behavior of the web-version
the same as #4 